### PR TITLE
Do not forbid resetting the default namespace…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1364,7 +1364,8 @@ dl.domintro::before {
           <p class=note>DOM APIs do allow creation of elements in the <a>XMLNS namespace</a> but
           with strict qualifications.</p>
 
-          <li>If the <a><var>require well-formed</var></a> flag is set (its value is <code>true</code>), and
+          <li>If the <a><var>require well-formed</var></a> flag is set (its value is <code>true</code>), the
+          value of <var>attr</var>'s <code><a>prefix</a></code> attribute is not <code>null</code>, and
           the value of <var>attr</var>'s <code><a>value</a></code> attribute is the empty string,
           then throw an exception; namespace prefix declarations cannot be used to undeclare a
           namespace (use a default namespace declaration instead).


### PR DESCRIPTION
 …when requiring well-formedness

At this point, the declaration may either be a prefix declaration or a default namespace declaration. While prefix declarations for the null namespace are not valid, it is allowed to reset the default namespace
this way.

Fixes #48