### PR TITLE
fix: Add `<dfn>` for the `[CEReactions]` IDL extended attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -1746,6 +1746,7 @@ dl.domintro::before {
         <dfn><a href="https://www.w3.org/TR/html5/single-page.html#the-template-element">template</a></dfn>
     <li><dfn><a href="https://www.w3.org/TR/html5/single-page.html#void-elements">void elements</a></dfn>
     <li>The <a>template</a>'s <dfn data-lt="template content"><a href="https://www.w3.org/TR/html5/single-page.html#template-contents">template contents</a></dfn>
+    <li>The <dfn data-lt="CEReactions"><a href="https://www.w3.org/TR/html5/single-page.html#cereactios">[CEReactions]</a></dfn> IDL <a>extended attribute</a>
   </ul>
 
   The DOM specification [[!DOM4]] defines the following terms used in this document:


### PR DESCRIPTION
This&nbsp;fixes **ReSpec**&nbsp;errors present&nbsp;in&nbsp;the&nbsp;document about&nbsp;`[CEReactions]` not&nbsp;having an&nbsp;associated&nbsp;`<dfn>`&nbsp;element.

---

review?(@travisleithead): You&nbsp;forgot&nbsp;this in&nbsp;<https://github.com/w3c/DOM-Parsing/pull/10>.