### PR TITLE
Upstream IDL changes from Trusted Types

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@ dl.domintro::before {
 
   <pre class="idl">
     interface mixin InnerHTML {
-      [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerHTML;
+      [CEReactions] attribute [LegacyNullToEmptyString] HTMLString innerHTML;
     };
 
     Element includes InnerHTML;
@@ -305,8 +305,8 @@ dl.domintro::before {
 
   <pre class="idl">
     partial interface Element {
-      [CEReactions] attribute [LegacyNullToEmptyString] DOMString outerHTML;
-      [CEReactions] undefined insertAdjacentHTML(DOMString position, DOMString text);
+      [CEReactions] attribute [LegacyNullToEmptyString] HTMLString outerHTML;
+      [CEReactions] undefined insertAdjacentHTML(DOMString position, HTMLString text);
     };
   </pre>
 
@@ -482,7 +482,7 @@ dl.domintro::before {
 
   <pre class="idl">
     partial interface Range {
-      [CEReactions, NewObject] DocumentFragment createContextualFragment(DOMString fragment);
+      [CEReactions, NewObject] DocumentFragment createContextualFragment(HTMLString fragment);
     };
   </pre>
 
@@ -1764,6 +1764,12 @@ dl.domintro::before {
 
   <ul>
     <li>The <dfn data-lt="LegacyNullToEmptyString"><a href="https://heycam.github.io/webidl/#LegacyNullToEmptyString">[LegacyNullToEmptyString]</a></dfn> IDL <a>extended attribute</a>
+  </ul>
+
+  The Trusted Types [[TRUSTED-TYPES]] specification defines:
+
+  <ul>
+    <li>The <dfn data-lt="HTMLString"><a href="https://w3c.github.io/trusted-types/dist/spec/#typedefdef-htmlstring">HTMLString</a></dfn> IDL <a>typedef</a>
   </ul>
 </section>
 

--- a/respecConfig.js
+++ b/respecConfig.js
@@ -7,9 +7,11 @@ var respecConfig = {
     { name: "Travis Leithead", company: "Microsoft", mailto: "travis.leithead@microsoft.com", companyURL: "http://www.microsoft.com", w3cid: "40117" }
   ],
   edDraftURI: "https://w3c.github.io/DOM-Parsing/",
+  xref: ["webidl", "html"],
   //format: "markdown",
   shortName:  "DOM-Parsing",
   wg:         ["Web Platform Working Group"],
+  group: "wg/webapps",
   wgURI:    ["https://www.w3.org/WebPlatform/WG/"],
   license: "w3c-software-doc",
   wgPublicList: "www-dom",


### PR DESCRIPTION
innerHTML, outerHTML, insertAdjacentHTML, and createContextualFragment all now take HTMLString values

Changes from https://w3c.github.io/trusted-types/dist/spec/#integration-with-dom-parsing

Tested in at https://wpt.live/trusted-types/